### PR TITLE
fix data merging of global and specific options

### DIFF
--- a/tasks/build_html.js
+++ b/tasks/build_html.js
@@ -53,7 +53,7 @@ module.exports = function(grunt) {
       if (typeof data == 'undefined') {
         data = {};
       }
-      data = _.extend(globalData, data);
+      data = _.extend({}, globalData, data);
 
       if (_.has(templates, tplName)) {
         files = _.clone(this.files);


### PR DESCRIPTION
Following the regression introduced in https://github.com/tonai/grunt-build-html/issues/2.
This will fix global options use by margin into a new object each iteration.
