### PR TITLE
Template namespace

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,7 @@ module.exports = function(grunt) {
       test: {
         options: {
           templates: ['test/fragments/**/*.html'],
+          templateNamespaceRoot: 'test/fragments'
         },
         expand: true,
         cwd: 'test/fixtures/',

--- a/tasks/build_html.js
+++ b/tasks/build_html.js
@@ -28,7 +28,8 @@ module.exports = function(grunt) {
 
     // Merge task-specific and/or target-specific options with these defaults.
     var options = this.options({
-      templates: []
+      templates: [],
+      templateNamespaceRoot: undefined
     });
 
     // Manage template settings.
@@ -76,10 +77,17 @@ module.exports = function(grunt) {
 
     // Process templates.
     _.each(grunt.file.expand(options.templates), function(tpl) {
-      var tplName = path.basename(tpl, path.extname(tpl)).replace(/[\s]/g, '_');
-      debug("loading template :", tplName);
-      debug("  path is :", tpl);
-      templates[tplName] = {
+      var tplKey = "";
+      if (options.templateNamespaceRoot) {
+        tplKey = path.relative(options.templateNamespaceRoot, path.dirname(tpl));
+        if ('tplKey', tplKey !== '') {;
+		  tplKey += '/';
+		}
+      }
+      tplKey += path.basename(tpl, path.extname(tpl)).replace(/[\s]/g, '_');
+      debug('loading template :', tplKey);
+      debug('  path is :', tpl);
+      templates[tplKey] = {
         content: grunt.file.read(tpl),
         filepath: tpl
       };

--- a/test/build_html_test.js
+++ b/test/build_html_test.js
@@ -51,6 +51,12 @@ exports.build_html = {
     test.equal(actual, expected, 'a simple skeleton is loaded with 2 params set, one of them is a submodule, this submodule simply loads a module.');
     test.done();
   },
+  includeContentHelloWorldFromSubfolder: function(test) {
+    var actual = grunt.file.read('tmp/include-content-hello-world-from-subfolder.html');
+    var expected = grunt.file.read('test/expected/include-content-hello-world-from-subfolder.html');
+    test.equal(actual, expected, 'test the correct behavior with namespaced templates');
+    test.done();
+  },
   missingParamDefault: function(test) {
     var actual = grunt.file.read('tmp/missing-params-default.html');
     var expected = grunt.file.read('test/expected/missing-params-default.html');

--- a/test/expected/include-content-hello-world-from-subfolder.html
+++ b/test/expected/include-content-hello-world-from-subfolder.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>My title</title>
+  </head>
+  <body>
+    Hello world into subfolder
+  </body>
+</html>

--- a/test/fixtures/include-content-hello-world-from-subfolder.html
+++ b/test/fixtures/include-content-hello-world-from-subfolder.html
@@ -1,0 +1,4 @@
+<%= include('simple-skeleton', {
+  title: 'My title',
+  body: include('subfolder/content-hello-world')
+}) %>

--- a/test/fragments/subfolder/content-hello-world.html
+++ b/test/fragments/subfolder/content-hello-world.html
@@ -1,0 +1,1 @@
+Hello world into subfolder


### PR DESCRIPTION
Pull request for the opened issue : https://github.com/tonai/grunt-build-html/issues/3.
Add the templateNamespaceRoot options.

Without it, it will simply load all templates with their filename as template key (regardless of the templates folder structure).
If you set the templates root folder, it will serve as the key origin :
template : test/fragments/subfolder/my-content.html
templateNamespaceRoot : test/fragments
template key : subfolder/my-content
